### PR TITLE
Correct typo and added .nojekyll file to instructions

### DIFF
--- a/brave/index.html
+++ b/brave/index.html
@@ -73,10 +73,11 @@
     </p>
     <h2>4. Verification file</h2>
     <p>
-      First create a directory called '.well-know' in the root of github pages
-      directory.
+      First create a file called '.nojekyll' in the root of github pages directory.
+    <p>
+      Then create a directory called '.well-known' in the same place.
     </p>
-    <p>Put the verification file in '.well-know' folder.</p>
+    <p>Put the verification file in '.well-known' folder.</p>
     <p>
       Do not change the verification file name 'brave-payments-verification.txt'
       or the file content.


### PR DESCRIPTION
Hi, I was reading the brave rewards tutorial and I noticed some differences with the brave instructions(.well-know instead of .well-known and no instructions about the .nojekyll file)